### PR TITLE
Defaults if empty config values refactoring

### DIFF
--- a/FuelSDK-CSharp/ETClient.cs
+++ b/FuelSDK-CSharp/ETClient.cs
@@ -52,10 +52,10 @@ namespace FuelSDK
         {
             // Get configuration file and set variables
             configSection = (FuelSDKConfigurationSection)ConfigurationManager.GetSection("fuelSDK");
+            configSection = (configSection != null ? (FuelSDKConfigurationSection)configSection.Clone() : new FuelSDKConfigurationSection());
             configSection = configSection
                 .WithDefaultAuthEndpoint(DefaultEndpoints.Auth)
                 .WithDefaultRestEndpoint(DefaultEndpoints.Rest);
-            configSection = (configSection != null ? (FuelSDKConfigurationSection)configSection.Clone() : new FuelSDKConfigurationSection());
             if (parameters != null)
             {
                 if (parameters.AllKeys.Contains("appSignature"))

--- a/FuelSDK-Test/FuelSDKConfigurationSectionTest.cs
+++ b/FuelSDK-Test/FuelSDKConfigurationSectionTest.cs
@@ -1,6 +1,5 @@
 ﻿using NUnit.Framework;
 using System.Configuration;
-using System.Linq;
 
 namespace FuelSDK.Test
 {
@@ -93,6 +92,21 @@ namespace FuelSDK.Test
 
             Assert.AreEqual(section.AuthenticationEndPoint, "https://authendpoint.com");
             Assert.AreEqual(section.RestEndPoint, "https://restendpoint.com");
+        }
+
+        [Test]
+        public void ModifyingAClonedConfigSectionAffectsTheOriginalSectionAndAnyNewInstance()
+        {
+            var section = (FuelSDKConfigurationSection)ConfigurationManager.GetSection("fuelSDK");
+            var clonedSection = (FuelSDKConfigurationSection)section.Clone();
+
+            clonedSection.SoapEndPoint = "https://soapendpoint.com";
+            var newSection = (FuelSDKConfigurationSection)ConfigurationManager.GetSection("fuelSDK");
+
+            Assert.AreEqual(object.ReferenceEquals(section, clonedSection), false);
+            Assert.AreNotSame(section, clonedSection);
+            Assert.AreEqual(section.SoapEndPoint, clonedSection.SoapEndPoint);
+            Assert.AreEqual(section.SoapEndPoint, newSection.SoapEndPoint);
         }
     }
 }


### PR DESCRIPTION
Changed the place where defaults are added in ET_Client. Added unit test to verify custom config section behavior.